### PR TITLE
selector-combinator-nesting rule fix

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -2272,11 +2272,12 @@ class PluginSelectorCombinatorNesting extends PluginBase {
 		});
 	}
 	precedesParentSelector(currentNode) {
-		let node;
 		do {
-			node = currentNode.next();
-			if (node?.type === 'nesting') return true;
-		} while (node?.next());
+			currentNode = currentNode?.next();
+			if (currentNode?.type === 'nesting') {
+				return true;
+			}
+		} while (currentNode?.next());
 		return false;
 	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-<a name="0.5.1"></a>
-# 0.5.1
+<a name="0.6.0"></a>
+# 0.6.0
 
 1. [x] Fixed: dependencies ([#16](https://github.com/kiforks/kifor-stylelint-config/pull/16)) ([@kiforks](https://github.com/kiforks)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 <a name="0.6.0"></a>
 # 0.6.0
 
+1. [x] Fixed: selector-combinator-nesting rule ([#17](https://github.com/kiforks/kifor-stylelint-config/pull/17)) ([@kiforks](https://github.com/kiforks)).
+
+<a name="0.5.1"></a>
+# 0.5.1
+
 1. [x] Fixed: dependencies ([#16](https://github.com/kiforks/kifor-stylelint-config/pull/16)) ([@kiforks](https://github.com/kiforks)).
 
 <a name="0.5.0"></a>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "kifor-stylelint-config",
 	"description": "Stylelint shareable config",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"exports": "./.stylelintrc.js",
 	"files": [
 		".stylelintrc.js"

--- a/src/core/plugin/plugins/plugin-selector-combinator-nesting/api/plugin-selector-combinator-nesting.ts
+++ b/src/core/plugin/plugins/plugin-selector-combinator-nesting/api/plugin-selector-combinator-nesting.ts
@@ -110,14 +110,14 @@ export class PluginSelectorCombinatorNesting extends PluginBase {
 		});
 	}
 
-	private precedesParentSelector(currentNode: selectorParser.Node): boolean {
-		let node: Nullable<selectorParser.Node>;
-
+	private precedesParentSelector(currentNode: Nullable<selectorParser.Node>): boolean {
 		do {
-			node = currentNode.next();
+			currentNode = currentNode?.next();
 
-			if (node?.type === 'nesting') return true;
-		} while (node?.next());
+			if (currentNode?.type === 'nesting') {
+				return true;
+			}
+		} while (currentNode?.next());
 
 		return false;
 	}


### PR DESCRIPTION

1. [x] Fixed: selector-combinator-nesting rule ([#17](https://github.com/kiforks/kifor-stylelint-config/pull/17)) ([@kiforks](https://github.com/kiforks)).